### PR TITLE
Fix keystore path in Android CI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Decode Keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-          KEYSTORE_PATH_IN_CI: android/release.jks # Define path here
+          KEYSTORE_PATH_IN_CI: release.jks # Path where the keystore will be written
         run: |
           echo "Decoding keystore..."
           mkdir -p $(dirname "$KEYSTORE_PATH_IN_CI") # Ensure directory exists
@@ -96,7 +96,7 @@ jobs:
       - name: Build Android APK (Signed)
         env:
           # Pass all necessary values as environment variables for Gradle
-          ANDROID_KEYSTORE_PATH_FROM_CI: android/release.jks # Path to the decoded keystore
+          ANDROID_KEYSTORE_PATH_FROM_CI: release.jks # Path to the decoded keystore
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
     signingConfigs {
         create("release") {
             // Directly use environment variables, which will be populated by GitHub Actions secrets
-            // The GitHub Actions workflow step 'Decode Keystore and Setup Signing' creates 'android/release.jks'
+            // The GitHub Actions workflow step "Decode Keystore" writes the key to 'release.jks' at the repository root
             // So, the path relative to this app/build.gradle.kts is '../release.jks'
             storeFile = rootProject.file("../release.jks") // Path to the keystore file created by CI
             storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")


### PR DESCRIPTION
## Summary
- point Android keystore to the repo root in CI
- update comment in Gradle file

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494e9be328832fbebb631c612b97aa