### PR TITLE
Fix Android settings persistence

### DIFF
--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -4,7 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'settings_model.dart';
 
 class SettingsService {
-  static const String _settingsKey = 'app_settings_v1'; // Added a version for future-proofing
+  static const String _settingsKey =
+      'app_settings_v1'; // Added a version for future-proofing
 
   Future<void> saveSettings(AppSettings settings) async {
     final prefs = await SharedPreferences.getInstance();
@@ -18,11 +19,12 @@ class SettingsService {
     if (settingsJson != null) {
       try {
         return AppSettings.fromMap(jsonDecode(settingsJson));
-        } catch (e) {
-          // Handle potential parsing errors, return defaults
-          debugPrint('Error loading settings: $e');
-          return AppSettings(); // Default if parsing fails
-        }
+      } catch (e) {
+        // Handle potential parsing errors, return defaults and clear corrupt data
+        debugPrint('Error loading settings: $e. Clearing stored settings.');
+        await prefs.remove(_settingsKey);
+        return AppSettings(); // Default if parsing fails
+      }
     }
     return AppSettings(); // Default if nothing saved
   }

--- a/test/settings_validation_test.dart
+++ b/test/settings_validation_test.dart
@@ -85,4 +85,14 @@ void main() {
     expect(service.saveCalled, isFalse);
     expect(find.byType(SettingsPage), findsOneWidget);
   });
+
+  test('corrupt settings are cleared on load', () async {
+    SharedPreferences.setMockInitialValues({'app_settings_v1': 'not json'});
+    final prefs = await SharedPreferences.getInstance();
+    final service = SettingsService();
+
+    final settings = await service.loadSettings();
+    expect(settings.width, AppSettings().width);
+    expect(prefs.getString('app_settings_v1'), isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- clear corrupt settings when loading fails to allow saving on Android
- test cleanup of corrupt saved data

## Testing
- `flutter analyze`
- `flutter test -r compact`

------
https://chatgpt.com/codex/tasks/task_e_684a46e4606c832fbecf76505d7e9bb9