### PR TITLE
Implement improved automata filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Key components:
 Image filtering is based on the 3×3 pattern frequency distribution in the output
 lines. The frequencies are sorted and linear regression is performed on the
 sorted counts to get a gradient. The gradient is normalized with `atan` and
-rejected if the normalized value is below 0.1 or above 0.9.
+rules are rejected if the normalized value falls outside the user-configurable
+minimum and maximum thresholds (defaults 0.1–0.8).
 
 To debug image filtering, `_generateRawPixelData` prints a summary line with the
 rule index, number of patterns counted, the top counts, and the gradient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This repository contains a Flutter app for browsing cellular automata images.
 Key components:
 - `main.dart` – home of `CellularAutomataPage`, which renders images for rules.
   - `_generateRawPixelData` computes each image line by line.
-  - It uses `_getSortedPatternCounts`, `_calculateGradient`, and `_passesGradientFilter`
-    to filter out rules that appear too simple. If a rule fails the filter, a
+  - Filtering helpers live in `pattern_utils.dart` (`getSortedPatternCounts`,
+    `calculateGradient`, `passesGradientFilter`). If a rule fails the filter, a
     1x1 white image is stored instead.
   - Image generation occurs synchronously on the main thread; the final scaling
     to an image is done using Canvas.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Notes
+
+This repository contains a Flutter app for browsing cellular automata images.
+Key components:
+- `main.dart` – home of `CellularAutomataPage`, which renders images for rules.
+  - `_generateRawPixelData` computes each image line by line.
+  - It uses `_getSortedPatternCounts`, `_calculateGradient`, and `_passesGradientFilter`
+    to filter out rules that appear too simple. If a rule fails the filter, a
+    1x1 white image is stored instead.
+  - Image generation occurs synchronously on the main thread; the final scaling
+    to an image is done using Canvas.
+- `settings_model.dart`, `settings_service.dart`, `settings_page.dart` – manage
+  app settings (bit number, width, height, seed points). Settings are stored via
+  `shared_preferences`.
+- Tests in `test/` verify the main page and settings page load and ensure corrupt
+  settings are handled.
+
+Image filtering is based on the 3×3 pattern frequency distribution in the output
+lines. The frequencies are sorted and linear regression is performed on the
+sorted counts to get a gradient. The gradient is normalized with `atan` and
+rejected if the normalized value is below 0.1 or above 0.9.
+
+To debug image filtering, `_generateRawPixelData` prints a summary line with the
+rule index, number of patterns counted, the top counts, and the gradient.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -587,6 +587,8 @@ class _CellularAutomataPageState extends State<CellularAutomataPage> {
         _currentSettings.width,
         _currentSettings.height,
         _currentSettings.seedPoints,
+        _currentSettings.minGradient,
+        _currentSettings.maxGradient,
       );
 
       final bool isSkipped = computeResult['isSkipped'] as bool;
@@ -803,6 +805,8 @@ class _CellularAutomataPageState extends State<CellularAutomataPage> {
     int cols,
     int rows,
     List<SeedPoint> seedPoints,
+    double minGradient,
+    double maxGradient,
   ) {
     // Bits for the rule
     final ruleBitsLength = 1 << pow;
@@ -875,11 +879,11 @@ class _CellularAutomataPageState extends State<CellularAutomataPage> {
     final counts = getSortedPatternCounts(lines);
     final gradient = calculateGradient(counts);
     final normalized = normalizedGradient(gradient);
-    final passes = passesGradientFilter(gradient);
+    final passes = passesGradientFilter(gradient, minGradient, maxGradient);
     if (kDebugMode) {
       final top = counts.take(5).join(',');
       print(
-          '[patternDebug] rule:$rule patterns:${counts.length} top:$top gradient:${gradient.toStringAsFixed(4)} normalized:${normalized.toStringAsFixed(4)} pass:$passes');
+          '[patternDebug] rule:$rule patterns:${counts.length} top:$top gradient:${gradient.toStringAsFixed(4)} normalized:${normalized.toStringAsFixed(4)} min:$minGradient max:$maxGradient pass:$passes');
     }
     if (!passes) {
       return {'isSkipped': true, 'pixelData': null};

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -874,7 +874,13 @@ class _CellularAutomataPageState extends State<CellularAutomataPage> {
 
     final counts = _getSortedPatternCounts(lines);
     final gradient = _calculateGradient(counts);
+    final normalized = _normalizedGradient(gradient);
     final passes = _passesGradientFilter(gradient);
+    if (kDebugMode) {
+      final top = counts.take(5).join(',');
+      print(
+          '[patternDebug] rule:$rule patterns:${counts.length} top:$top gradient:${gradient.toStringAsFixed(4)} normalized:${normalized.toStringAsFixed(4)} pass:$passes');
+    }
     if (!passes) {
       return {'isSkipped': true, 'pixelData': null};
     }
@@ -930,7 +936,8 @@ List<int> _getSortedPatternCounts(List<List<bool>> lines) {
       counts[val]++;
     }
   }
-  final sorted = List<int>.from(counts)..sort((a, b) => b.compareTo(a));
+  final sorted = counts.where((c) => c > 0).toList()
+    ..sort((a, b) => b.compareTo(a));
   return sorted;
 }
 
@@ -956,6 +963,10 @@ double _calculateGradient(List<int> sortedCounts) {
 }
 
 bool _passesGradientFilter(double gradient) {
-  final normalized = (2 / math.pi) * math.atan(gradient.abs());
+  final normalized = _normalizedGradient(gradient);
   return normalized > 0.1 && normalized < 0.9;
+}
+
+double _normalizedGradient(double gradient) {
+  return (2 / math.pi) * math.atan(gradient.abs());
 }

--- a/lib/pattern_utils.dart
+++ b/lib/pattern_utils.dart
@@ -61,7 +61,11 @@ double normalizedGradient(double gradient) {
 }
 
 /// Returns true if [gradient] falls within the middle 80% of the possible range.
-bool passesGradientFilter(double gradient) {
+bool passesGradientFilter(
+  double gradient,
+  double minNormalized,
+  double maxNormalized,
+) {
   final normalized = normalizedGradient(gradient);
-  return normalized > 0.12 && normalized < 0.88;
+  return normalized > minNormalized && normalized < maxNormalized;
 }

--- a/lib/pattern_utils.dart
+++ b/lib/pattern_utils.dart
@@ -1,0 +1,67 @@
+import 'dart:math' as math;
+
+/// Counts all 3x3 patterns within [lines] and returns the non-zero counts
+/// sorted from most to least frequent.
+List<int> getSortedPatternCounts(List<List<bool>> lines) {
+  if (lines.length < 3 || lines[0].length < 3) {
+    return [];
+  }
+  final counts = List<int>.filled(512, 0);
+  final rows = lines.length;
+  final cols = lines[0].length;
+  for (int r = 0; r < rows - 2; r++) {
+    for (int c = 0; c < cols - 2; c++) {
+      int val = 0;
+      for (int dr = 0; dr < 3; dr++) {
+        for (int dc = 0; dc < 3; dc++) {
+          if (lines[r + dr][c + dc]) {
+            val |= 1 << (dr * 3 + dc);
+          }
+        }
+      }
+      counts[val]++;
+    }
+  }
+  final sorted = counts.where((c) => c > 0).toList()
+    ..sort((a, b) => b.compareTo(a));
+  return sorted;
+}
+
+/// Performs a simple linear regression on [sortedCounts], using the
+/// logarithm of each count value to keep large counts from dominating.
+double calculateGradient(List<int> sortedCounts) {
+  if (sortedCounts.isEmpty) return 0;
+  final logs = sortedCounts.map((c) => math.log(c.toDouble())).toList();
+  final ranks =
+      List<double>.generate(sortedCounts.length, (i) => math.log((i + 1).toDouble()));
+  final n = logs.length;
+  double sumX = 0;
+  double sumY = 0;
+  double sumXY = 0;
+  double sumX2 = 0;
+  for (int i = 0; i < n; i++) {
+    final x = ranks[i];
+    final y = logs[i];
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+  }
+  final numerator = n * sumXY - sumX * sumY;
+  final denominator = n * sumX2 - sumX * sumX;
+  if (denominator == 0) return 0;
+  return numerator / denominator;
+}
+
+/// Maps [gradient] to a value between 0 and 1. Values near 0 represent
+/// flat gradients (random), while values near 1 represent very steep slopes
+/// (highly ordered).
+double normalizedGradient(double gradient) {
+  return (2 / math.pi) * math.atan(gradient.abs());
+}
+
+/// Returns true if [gradient] falls within the middle 80% of the possible range.
+bool passesGradientFilter(double gradient) {
+  final normalized = normalizedGradient(gradient);
+  return normalized > 0.12 && normalized < 0.88;
+}

--- a/lib/settings_model.dart
+++ b/lib/settings_model.dart
@@ -17,18 +17,22 @@ class AppSettings {
   int width;
   int height;
   List<SeedPoint> seedPoints;
+  double minGradient;
+  double maxGradient;
 
   AppSettings({
     this.bitNumber = 4, // Default for pow
     this.width = 400,
     this.height = 1000,
     List<SeedPoint>? seedPoints,
+    this.minGradient = 0.1,
+    this.maxGradient = 0.8,
   }) : seedPoints =
            seedPoints ??
            [
              SeedPoint(fraction: 0.25, pixels: 1),
              SeedPoint(fraction: 1 / 3, pixels: 1),
-             SeedPoint(fraction: 2 / 3, pixels: 1),
+              SeedPoint(fraction: 2 / 3, pixels: 1),
            ];
 
   // For storing as a single JSON string in shared_preferences
@@ -38,6 +42,8 @@ class AppSettings {
       'width': width,
       'height': height,
       'seedPoints': seedPoints.map((e) => e.toMap()).toList(),
+      'minGradient': minGradient,
+      'maxGradient': maxGradient,
     };
   }
 
@@ -54,6 +60,8 @@ class AppSettings {
       width: map['width'] ?? 400,
       height: map['height'] ?? 1000,
       seedPoints: seeds,
+      minGradient: (map['minGradient'] as num?)?.toDouble() ?? 0.1,
+      maxGradient: (map['maxGradient'] as num?)?.toDouble() ?? 0.8,
     );
   }
 }

--- a/lib/settings_model.dart
+++ b/lib/settings_model.dart
@@ -4,35 +4,32 @@ class SeedPoint {
 
   SeedPoint({this.fraction = 0.5, this.pixels = 1});
 
-  Map<String, dynamic> toMap() => {
-        'fraction': fraction,
-        'pixels': pixels,
-      };
+  Map<String, dynamic> toMap() => {'fraction': fraction, 'pixels': pixels};
 
   factory SeedPoint.fromMap(Map<String, dynamic> map) => SeedPoint(
-        fraction: (map['fraction'] as num?)?.toDouble() ?? 0.5,
-        pixels: map['pixels'] ?? 1,
-      );
+    fraction: (map['fraction'] as num?)?.toDouble() ?? 0.5,
+    pixels: map['pixels'] ?? 1,
+  );
 }
 
 class AppSettings {
   int bitNumber;
   int width;
   int height;
-  int minLines;
   List<SeedPoint> seedPoints;
 
   AppSettings({
     this.bitNumber = 4, // Default for pow
     this.width = 400,
     this.height = 1000,
-    this.minLines = 25,
     List<SeedPoint>? seedPoints,
-  }) : seedPoints = seedPoints ?? [
-          SeedPoint(fraction: 0.25, pixels: 1),
-          SeedPoint(fraction: 1 / 3, pixels: 1),
-          SeedPoint(fraction: 2 / 3, pixels: 1),
-        ];
+  }) : seedPoints =
+           seedPoints ??
+           [
+             SeedPoint(fraction: 0.25, pixels: 1),
+             SeedPoint(fraction: 1 / 3, pixels: 1),
+             SeedPoint(fraction: 2 / 3, pixels: 1),
+           ];
 
   // For storing as a single JSON string in shared_preferences
   Map<String, dynamic> toMap() {
@@ -40,7 +37,6 @@ class AppSettings {
       'bitNumber': bitNumber,
       'width': width,
       'height': height,
-      'minLines': minLines,
       'seedPoints': seedPoints.map((e) => e.toMap()).toList(),
     };
   }
@@ -57,7 +53,6 @@ class AppSettings {
       bitNumber: map['bitNumber'] ?? 4,
       width: map['width'] ?? 400,
       height: map['height'] ?? 1000,
-      minLines: map['minLines'] ?? 25,
       seedPoints: seeds,
     );
   }

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -20,7 +20,6 @@ class _SettingsPageState extends State<SettingsPage> {
   final _formKey = GlobalKey<FormState>();
   late TextEditingController _widthController;
   late TextEditingController _heightController;
-  late TextEditingController _minLinesController;
   late int _selectedBitNumber;
   late List<SeedPoint> _seedPoints;
 
@@ -28,9 +27,12 @@ class _SettingsPageState extends State<SettingsPage> {
   void initState() {
     super.initState();
     _selectedBitNumber = widget.initialSettings.bitNumber;
-    _widthController = TextEditingController(text: widget.initialSettings.width.toString());
-    _heightController = TextEditingController(text: widget.initialSettings.height.toString());
-    _minLinesController = TextEditingController(text: widget.initialSettings.minLines.toString());
+    _widthController = TextEditingController(
+      text: widget.initialSettings.width.toString(),
+    );
+    _heightController = TextEditingController(
+      text: widget.initialSettings.height.toString(),
+    );
     _seedPoints = widget.initialSettings.seedPoints
         .map((e) => SeedPoint(fraction: e.fraction, pixels: e.pixels))
         .toList();
@@ -40,7 +42,6 @@ class _SettingsPageState extends State<SettingsPage> {
   void dispose() {
     _widthController.dispose();
     _heightController.dispose();
-    _minLinesController.dispose();
     super.dispose();
   }
 
@@ -50,7 +51,6 @@ class _SettingsPageState extends State<SettingsPage> {
         bitNumber: _selectedBitNumber,
         width: int.parse(_widthController.text),
         height: int.parse(_heightController.text),
-        minLines: int.parse(_minLinesController.text),
         seedPoints: _seedPoints,
       );
 
@@ -79,9 +79,7 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Settings'),
-      ),
+      appBar: AppBar(title: const Text('Settings')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Form(
@@ -94,12 +92,16 @@ class _SettingsPageState extends State<SettingsPage> {
                   labelText: 'Bit Number (3-8)',
                   border: OutlineInputBorder(),
                 ),
-                items: List.generate(6, (index) => index + 3) // Generates 3, 4, 5, 6, 7, 8
-                    .map((bit) => DropdownMenuItem(
-                          value: bit,
-                          child: Text('$bit'),
-                        ))
-                    .toList(),
+                items:
+                    List.generate(
+                          6,
+                          (index) => index + 3,
+                        ) // Generates 3, 4, 5, 6, 7, 8
+                        .map(
+                          (bit) =>
+                              DropdownMenuItem(value: bit, child: Text('$bit')),
+                        )
+                        .toList(),
                 onChanged: (value) {
                   if (value != null) {
                     setState(() {
@@ -117,10 +119,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
                 keyboardType: TextInputType.number,
                 validator: (value) {
-                  if (value == null || value.isEmpty) return 'Please enter a width.';
+                  if (value == null || value.isEmpty)
+                    return 'Please enter a width.';
                   final n = int.tryParse(value);
                   if (n == null) return 'Please enter a valid number.';
-                  if (n < 1 || n > 2000) return 'Width must be between 1 and 2000.';
+                  if (n < 1 || n > 2000)
+                    return 'Width must be between 1 and 2000.';
                   return null;
                 },
               ),
@@ -133,26 +137,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
                 keyboardType: TextInputType.number,
                 validator: (value) {
-                  if (value == null || value.isEmpty) return 'Please enter a height.';
+                  if (value == null || value.isEmpty)
+                    return 'Please enter a height.';
                   final n = int.tryParse(value);
                   if (n == null) return 'Please enter a valid number.';
-                  if (n < 1 || n > 5000) return 'Height must be between 1 and 5000.';
-                  return null;
-                },
-              ),
-              const SizedBox(height: 16),
-              TextFormField(
-                controller: _minLinesController,
-                decoration: const InputDecoration(
-                  labelText: 'Minimum Unique Lines (MinLines)',
-                  border: OutlineInputBorder(),
-                ),
-                keyboardType: TextInputType.number,
-                validator: (value) {
-                  if (value == null || value.isEmpty) return 'Please enter a minimum number of lines.';
-                  final n = int.tryParse(value);
-                  if (n == null) return 'Please enter a valid number.';
-                  if (n < 1) return 'Minimum lines must be at least 1.';
+                  if (n < 1 || n > 5000)
+                    return 'Height must be between 1 and 5000.';
                   return null;
                 },
               ),
@@ -178,10 +168,12 @@ class _SettingsPageState extends State<SettingsPage> {
                           isExpanded: true,
                           value: sp.pixels.clamp(1, 8),
                           items: List.generate(8, (i) => i + 1)
-                              .map((v) => DropdownMenuItem(
-                                    value: v,
-                                    child: Text('$v'),
-                                  ))
+                              .map(
+                                (v) => DropdownMenuItem(
+                                  value: v,
+                                  child: Text('$v'),
+                                ),
+                              )
                               .toList(),
                           onChanged: (val) {
                             if (val != null) {

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -22,6 +22,8 @@ class _SettingsPageState extends State<SettingsPage> {
   late TextEditingController _heightController;
   late int _selectedBitNumber;
   late List<SeedPoint> _seedPoints;
+  late double _minGradient;
+  late double _maxGradient;
 
   @override
   void initState() {
@@ -36,6 +38,8 @@ class _SettingsPageState extends State<SettingsPage> {
     _seedPoints = widget.initialSettings.seedPoints
         .map((e) => SeedPoint(fraction: e.fraction, pixels: e.pixels))
         .toList();
+    _minGradient = widget.initialSettings.minGradient;
+    _maxGradient = widget.initialSettings.maxGradient;
   }
 
   @override
@@ -52,6 +56,8 @@ class _SettingsPageState extends State<SettingsPage> {
         width: int.parse(_widthController.text),
         height: int.parse(_heightController.text),
         seedPoints: _seedPoints,
+        minGradient: _minGradient,
+        maxGradient: _maxGradient,
       );
 
       await widget.settingsService.saveSettings(newSettings);
@@ -144,6 +150,34 @@ class _SettingsPageState extends State<SettingsPage> {
                   if (n < 1 || n > 5000)
                     return 'Height must be between 1 and 5000.';
                   return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              Text('Minimum gradient (${_minGradient.toStringAsFixed(2)})'),
+              Slider(
+                min: 0.0,
+                max: 1.0,
+                divisions: 100,
+                value: _minGradient,
+                onChanged: (v) {
+                  setState(() {
+                    _minGradient = v;
+                    if (_minGradient > _maxGradient) _maxGradient = v;
+                  });
+                },
+              ),
+              const SizedBox(height: 16),
+              Text('Maximum gradient (${_maxGradient.toStringAsFixed(2)})'),
+              Slider(
+                min: 0.0,
+                max: 1.0,
+                divisions: 100,
+                value: _maxGradient,
+                onChanged: (v) {
+                  setState(() {
+                    _maxGradient = v;
+                    if (_maxGradient < _minGradient) _minGradient = v;
+                  });
                 },
               ),
               const SizedBox(height: 24),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+1
+version: 1.0.2+1
 
 environment:
   sdk: ^3.8.1

--- a/test/gradient_filter_test.dart
+++ b/test/gradient_filter_test.dart
@@ -58,14 +58,14 @@ void main() {
     final lines = _generateLines(2, 3, cols, rows, seeds);
     final counts = getSortedPatternCounts(lines);
     final grad = calculateGradient(counts);
-    expect(passesGradientFilter(grad), isFalse);
+    expect(passesGradientFilter(grad, 0.1, 0.8), isFalse);
   });
 
   test('3-bit rule 30 passes gradient filter', () {
     final lines = _generateLines(30, 3, cols, rows, seeds);
     final counts = getSortedPatternCounts(lines);
     final grad = calculateGradient(counts);
-    expect(passesGradientFilter(grad), isTrue);
+    expect(passesGradientFilter(grad, 0.1, 0.8), isTrue);
   });
 }
 

--- a/test/gradient_filter_test.dart
+++ b/test/gradient_filter_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:celly_viewer/pattern_utils.dart';
+import 'package:celly_viewer/settings_model.dart';
+
+List<List<bool>> _generateLines(
+  int rule,
+  int pow,
+  int cols,
+  int rows,
+  List<SeedPoint> seeds,
+) {
+  final ruleBits =
+      List<bool>.generate(1 << pow, (i) => ((rule >> i) & 1) == 1);
+  List<bool> line = List<bool>.filled(cols, false);
+  for (final sp in seeds) {
+    final base = (sp.fraction * cols).floor();
+    if (base >= 0 && base < cols) {
+      line[base] = true;
+    }
+    for (int i = 1; i < sp.pixels; i++) {
+      final offset = ((i - 1) ~/ 2) + 1;
+      final after = i % 2 == 1;
+      final idx = after ? base + offset : base - offset;
+      if (idx >= 0 && idx < cols) {
+        line[idx] = true;
+      }
+    }
+  }
+
+  final lines = <List<bool>>[];
+  for (int l = 0; l < rows; l++) {
+    lines.add(List<bool>.from(line));
+    final newLine = List<bool>.from(line);
+    for (int i = 0; i < line.length - pow; i++) {
+      int val = 0;
+      for (int j = 0; j < pow; j++) {
+        if (line[i + j]) {
+          val |= 1 << j;
+        }
+      }
+      newLine[i + (pow ~/ 2)] = ruleBits[val];
+    }
+    line = newLine;
+  }
+  return lines;
+}
+
+void main() {
+  final seeds = [
+    SeedPoint(fraction: 0.25, pixels: 1),
+    SeedPoint(fraction: 1 / 3, pixels: 1),
+    SeedPoint(fraction: 2 / 3, pixels: 1),
+  ];
+  const cols = 1500;
+  const rows = 3000;
+
+  test('3-bit rule 2 is measured as too simple', () {
+    final lines = _generateLines(2, 3, cols, rows, seeds);
+    final counts = getSortedPatternCounts(lines);
+    final grad = calculateGradient(counts);
+    expect(passesGradientFilter(grad), isFalse);
+  });
+
+  test('3-bit rule 30 passes gradient filter', () {
+    final lines = _generateLines(30, 3, cols, rows, seeds);
+    final counts = getSortedPatternCounts(lines);
+    final grad = calculateGradient(counts);
+    expect(passesGradientFilter(grad), isTrue);
+  });
+}
+

--- a/test/settings_validation_test.dart
+++ b/test/settings_validation_test.dart
@@ -47,29 +47,6 @@ void main() {
     expect(fieldWidget.controller?.text, '0');
   });
 
-  testWidgets('invalid minLines value not saved', (WidgetTester tester) async {
-    final service = TestSettingsService();
-    await tester.pumpWidget(
-      MaterialApp(
-        home: SettingsPage(
-          initialSettings: AppSettings(),
-          settingsService: service,
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final minLinesField = find.widgetWithText(
-      TextFormField,
-      'Minimum Unique Lines (MinLines)',
-    );
-    await tester.enterText(minLinesField, 'abc');
-    final formState = tester.state<FormState>(find.byType(Form));
-    expect(formState.validate(), isFalse);
-    expect(service.saveCalled, isFalse);
-    expect(find.byType(SettingsPage), findsOneWidget);
-  });
-
   testWidgets('invalid width value not saved', (WidgetTester tester) async {
     final service = TestSettingsService();
     await tester.pumpWidget(
@@ -91,8 +68,9 @@ void main() {
   });
 
   test('corrupt settings are cleared on load', () async {
-    final backend =
-        InMemorySharedPreferencesAsync.withData({'app_settings_v1': 'not json'});
+    final backend = InMemorySharedPreferencesAsync.withData({
+      'app_settings_v1': 'not json',
+    });
     SharedPreferencesAsyncPlatform.instance = backend;
     final service = SettingsService();
 


### PR DESCRIPTION
## Summary
- compute 3x3 pattern distributions for automata renders
- derive a linear-regression gradient from the pattern counts
- filter rules based on the gradient instead of unique line counts
- remove unique line filtering logic and associated setting
- update tests for new settings

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684ba5541624832f8d6268273845635f