### PR TITLE
Update list rendering behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,5 +21,17 @@ sorted counts to get a gradient. The gradient is normalized with `atan` and
 rules are rejected if the normalized value falls outside the user-configurable
 minimum and maximum thresholds (defaults 0.1–0.8).
 
+## Development Notes
+
+- The image list uses `_DisplayEntry` objects. Rendered images are `_ImageEntry`
+  instances, while skipped sequences are stored as a single `_SkippedEntry`
+  containing a count of skipped items.
+- A `_generationToken` increments whenever the list is reset. Results from
+  previous generations are ignored if their token does not match the current
+  one.
+- Scroll events only queue more images when no generation tasks are currently
+  running to avoid runaway loops.
+- Always run `flutter test` before committing changes.
+
 To debug image filtering, `_generateRawPixelData` prints a summary line with the
 rule index, number of patterns counted, the top counts, and the gradient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,16 @@ minimum and maximum thresholds (defaults 0.1–0.8).
 - The image list uses `_DisplayEntry` objects. Rendered images are `_ImageEntry`
   instances, while skipped sequences are stored as a single `_SkippedEntry`
   containing a count of skipped items.
+- Generating rules insert a `_GeneratingEntry` placeholder which is replaced
+  when generation completes. This keeps items ordered even if tasks finish out of
+  sequence.
 - A `_generationToken` increments whenever the list is reset. Results from
   previous generations are ignored if their token does not match the current
   one.
 - Scroll events only queue more images when no generation tasks are currently
   running to avoid runaway loops.
+- Scroll processing is debounced for one second after list modifications to
+  prevent runaway generation when items are evicted.
 - Always run `flutter test` before committing changes.
 
 To debug image filtering, `_generateRawPixelData` prints a summary line with the


### PR DESCRIPTION
## Summary
- compress skipped images into single rows
- avoid adding widgets for items not rendered yet
- render new images in the background
- show only one loading spinner at the end of the list
- manage displayed items and cache evictions consistently

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684bdff0d038832fbac7aa7867ff9259